### PR TITLE
Profile page front 

### DIFF
--- a/app-next/app/profile/page.js
+++ b/app-next/app/profile/page.js
@@ -1,0 +1,5 @@
+import ProfilePage from "@/components/ProfilePage/ProfilePage.jsx";
+
+export default function Profile() {
+  return <ProfilePage />;
+}

--- a/app-next/components/General/Switch.jsx
+++ b/app-next/components/General/Switch.jsx
@@ -1,0 +1,32 @@
+import { useState } from "react";
+import styles from "./Switch.module.css";
+
+const Switch = ({ initialState = false, onChange, disabled = false }) => {
+  const [isOn, setIsOn] = useState(initialState);
+
+  const handleToggle = () => {
+    if (!disabled) {
+      const newState = !isOn;
+      setIsOn(newState);
+      if (onChange) {
+        onChange(newState);
+      }
+    }
+  };
+
+  return (
+    <button
+      className={`${styles.switch} ${isOn ? styles.on : styles.off} ${
+        disabled ? styles.disabled : ""
+      }`}
+      onClick={handleToggle}
+      disabled={disabled}
+      aria-checked={isOn}
+      role="switch"
+    >
+      <span className={styles.slider}></span>
+    </button>
+  );
+};
+
+export default Switch;

--- a/app-next/components/General/Switch.module.css
+++ b/app-next/components/General/Switch.module.css
@@ -1,0 +1,48 @@
+.switch {
+  position: relative;
+  width: 50px;
+  height: 24px;
+  border: none;
+  border-radius: 24px;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+  outline: none;
+  padding: 0;
+}
+
+.switch:focus {
+  box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
+}
+
+.off {
+  background-color: #ccc;
+}
+
+.on {
+  background-color: #007bff;
+}
+
+.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.slider {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background-color: white;
+  transition: transform 0.3s ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+}
+
+.on .slider {
+  transform: translateX(26px);
+}
+
+.switch:active .slider {
+  width: 22px;
+}

--- a/app-next/components/ProfilePage/ProfileCard.jsx
+++ b/app-next/components/ProfilePage/ProfileCard.jsx
@@ -1,0 +1,13 @@
+import styles from "./ProfilePage.module.css";
+
+export default function ProfileCard({ icon, name, content }) {
+  return (
+    <div className={styles.card}>
+      <div className={styles.icon}>{icon}</div>
+      <div className={styles.details}>
+        <h4 className={styles.name}>{name}</h4>
+        <p className={styles.content}>{content}</p>
+      </div>
+    </div>
+  );
+}

--- a/app-next/components/ProfilePage/ProfilePage.jsx
+++ b/app-next/components/ProfilePage/ProfilePage.jsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from "react";
 import styles from "./ProfilePage.module.css";
 import Image from "next/image";
 import ProfileCard from "./ProfileCard";
+import Switch from "../General/Switch";
 import {
   FiUser,
   FiMail,
@@ -10,6 +11,10 @@ import {
   FiCalendar,
   FiBriefcase,
 } from "react-icons/fi";
+
+const handleSwitchChange = (settingName, value) => {
+  console.log(`${settingName} changed to:`, value);
+};
 
 export default function ProfilePage() {
   const [user, setUser] = useState(null);
@@ -62,13 +67,13 @@ export default function ProfilePage() {
             <p>{user.email}</p>
           </div>
         </div>
-        <button className={styles.editButton} aria-label="Edit user profile">
+        <button className={styles.pageButton} aria-label="Edit user profile">
           Edit Profile
         </button>
       </section>
 
       <section
-        className={styles.profileDetails}
+        className={styles.section}
         aria-labelledby="user-profile-details"
       >
         <h2>Personal Information</h2>
@@ -98,6 +103,56 @@ export default function ProfilePage() {
             name="Role"
             content={user.role || "Not specified"}
           />
+        </div>
+      </section>
+      <section
+        className={styles.section}
+        aria-labelledby="user-profile-activity"
+      >
+        <h2>Account Settings</h2>
+        <div className={styles.settingsRow}>
+          <div className={styles.settingsCard}>
+            <h3>Account Security</h3>
+            <div className={styles.settingsCardOption}>
+              <p>Password</p>
+              <button className={styles.pageButton}>Change Password</button>
+            </div>
+            <div className={styles.settingsCardOption}>
+              <p>Two-Factor Authentication</p>
+              <Switch
+                initialState={false}
+                onChange={(value) => handleSwitchChange("2FA", value)}
+              />
+            </div>
+            <div className={styles.settingsCardOption}>
+              <p>Recent Activity</p>
+              <button className={styles.pageButton}>View Activity</button>
+            </div>
+          </div>
+          <div className={styles.settingsCard}>
+            <h3>Notification Preferences</h3>
+            <div className={styles.settingsCardOption}>
+              <p>Email Notifications</p>
+              <Switch
+                initialState={true}
+                onChange={(value) => handleSwitchChange("email", value)}
+              />
+            </div>
+            <div className={styles.settingsCardOption}>
+              <p>SMS Notifications</p>
+              <Switch
+                initialState={false}
+                onChange={(value) => handleSwitchChange("sms", value)}
+              />
+            </div>
+            <div className={styles.settingsCardOption}>
+              <p>In-app Notifications</p>
+              <Switch
+                initialState={true}
+                onChange={(value) => handleSwitchChange("inApp", value)}
+              />
+            </div>
+          </div>
         </div>
       </section>
     </main>

--- a/app-next/components/ProfilePage/ProfilePage.jsx
+++ b/app-next/components/ProfilePage/ProfilePage.jsx
@@ -1,0 +1,105 @@
+"use client";
+import { useState, useEffect } from "react";
+import styles from "./ProfilePage.module.css";
+import Image from "next/image";
+import ProfileCard from "./ProfileCard";
+import {
+  FiUser,
+  FiMail,
+  FiPhone,
+  FiCalendar,
+  FiBriefcase,
+} from "react-icons/fi";
+
+export default function ProfilePage() {
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchUserData = async () => {
+      try {
+        const response = await fetch("/data/user.json");
+        const userData = await response.json();
+        setUser(userData);
+      } catch (error) {
+        console.error("Error fetching user data:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchUserData();
+  }, []);
+
+  if (loading) {
+    return <div className={styles.loading}>Loading profile...</div>;
+  }
+
+  if (!user) {
+    return <div className={styles.error}>Failed to load profile data</div>;
+  }
+
+  return (
+    <main className={styles.profileContainer}>
+      <header>
+        <h1 className={styles.profileHeader}>Profile Overview</h1>
+      </header>
+
+      <section className={styles.profileTop} aria-labelledby="user-info">
+        <div className={styles.userDetails}>
+          <Image
+            src={user.profile_picture}
+            alt={`${user.first_name} ${user.last_name}`}
+            width={100}
+            height={100}
+            className={styles.profileImage}
+            onError={(e) => {
+              e.target.src = "/images/default-avatar.jpg";
+            }}
+          />
+          <div className={styles.userName}>
+            <h2>{`${user.first_name} ${user.last_name}`}</h2>
+            <p>{user.email}</p>
+          </div>
+        </div>
+        <button className={styles.editButton} aria-label="Edit user profile">
+          Edit Profile
+        </button>
+      </section>
+
+      <section
+        className={styles.profileDetails}
+        aria-labelledby="user-profile-details"
+      >
+        <h2>Personal Information</h2>
+        <div className={styles.cardGrid}>
+          <ProfileCard
+            icon={<FiUser />}
+            name="Full Name"
+            content={`${user.first_name} ${user.last_name}`}
+          />
+          <ProfileCard
+            icon={<FiMail />}
+            name="Email Address"
+            content={user.email}
+          />
+          <ProfileCard
+            icon={<FiPhone />}
+            name="Phone"
+            content={user.phone_number}
+          />
+          <ProfileCard
+            icon={<FiCalendar />}
+            name="Birthday"
+            content={user.date_of_birth}
+          />
+          <ProfileCard
+            icon={<FiBriefcase />}
+            name="Role"
+            content={user.role || "Not specified"}
+          />
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app-next/components/ProfilePage/ProfilePage.module.css
+++ b/app-next/components/ProfilePage/ProfilePage.module.css
@@ -1,0 +1,78 @@
+.profileContainer {
+  padding: 20px;
+  max-width: 800px;
+  margin: 0 auto;
+  background-color: #f9f9f9;
+}
+
+.profileHeader {
+  margin: 0 24px;
+}
+
+.profileHeader h1 {
+  margin: 0 0 20px 0;
+}
+
+.profileTop {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  margin: 20px 0;
+  background-color: rgb(253, 253, 253);
+  border: 1px solid #faededae;
+  padding: 20px 24px;
+  margin: 20px 24px;
+}
+
+.userDetails {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
+
+.profileImage {
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.userName h2 {
+  margin: 0 0 5px 0;
+}
+
+.profileDetails {
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  padding: 12px;
+  border: 1px solid #faededae;
+  border-radius: 8px;
+  margin-bottom: 12px;
+  background-color: rgb(253, 253, 253);
+}
+
+.details {
+  flex-grow: 1;
+}
+
+.name {
+  color: #555;
+}
+
+.content {
+  font-weight: bold;
+}
+
+.cardGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 20px;
+}

--- a/app-next/components/ProfilePage/ProfilePage.module.css
+++ b/app-next/components/ProfilePage/ProfilePage.module.css
@@ -43,10 +43,19 @@
   margin: 0 0 5px 0;
 }
 
-.profileDetails {
+.userName p {
+  color: #555;
+}
+
+.section {
   padding: 24px;
   display: flex;
   flex-direction: column;
+}
+
+.section h2 {
+  margin: 0 0 16px 0;
+  color: #333;
 }
 
 .card {
@@ -68,11 +77,59 @@
 }
 
 .content {
-  font-weight: bold;
+  font-weight: 600;
 }
 
 .cardGrid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 20px;
+}
+
+.settingsRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-direction: row;
+  gap: 12px;
+  padding: 12px 0;
+  border-bottom: 1px solid #eee;
+}
+
+.settingsCard {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background-color: rgb(253, 253, 253);
+  border: 1px solid #faededae;
+  border-radius: 8px;
+  width: 100%;
+  overflow: hidden;
+}
+
+.settingsCardOption {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid #55555584;
+  padding: 12px 16px;
+  min-height: 44px;
+}
+
+.settingsCardOption:last-child {
+  border-bottom: none;
+}
+
+.pageButton {
+  padding: 8px 16px;
+  background-color: #ffffff;
+  border: 1px solid #cccccca2;
+  border-radius: 4px;
+  cursor: pointer;
+  text-align: center;
+  font-weight: 500;
+}
+
+.pageButton:hover {
+  background-color: #f0f0f0;
 }

--- a/app-next/public/data/user.json
+++ b/app-next/public/data/user.json
@@ -1,0 +1,10 @@
+{
+  "id": 1,
+  "first_name": "John",
+  "last_name": "Doe",
+  "email": "john.doe@example.com",
+  "phone_number": "+1-234-567-8900",
+  "date_of_birth": "1990-05-15",
+  "profile_picture": "https://plus.unsplash.com/premium_photo-1689530775582-83b8abdb5020?fm=jpg&q=60&w=3000&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8cmFuZG9tJTIwcGVyc29ufGVufDB8fDB8fHww",
+  "role": "Software Engineer"
+}


### PR DESCRIPTION
I created my-profile page with the same design as Visily. The only thing I changed is view activity button to be the same as other buttons on the page. The screenshots are provided below. General breakdown:
1. For the moment, the data for user is fetched from public/data/user.json. After setting up the backend,  it can be switched easily(check fetching in ProfilePage.jsx component).
2. The layout is simple, css grid for the personal information(pic2), the rest is flex
3. I installed react icons library for Icons in personal information(pic2), don't forget to run npm install after merging and pulling later.
4. I created a Switch component(pic3) and put it in General folder in components folder, in case we will need to use it for other pages. If you will come up with any other reusable components, please put them in General as well.
5. IMPORTANT! I did not add any media queries to the page. I have an idea how to make responsiveness more global and easy. I will test some things and present my idea on Sunday. If it will be rejected, I will put media queries manually here

![profile1](https://github.com/user-attachments/assets/1b795d2e-6a7d-4f07-85a4-dbb292caf86c)
![profile2](https://github.com/user-attachments/assets/281ecf00-19e7-4f57-9018-561626cb697d)
![profile3](https://github.com/user-attachments/assets/eaeb7619-519d-4a4a-8920-c070de08ad45)
