### PR TITLE
Fix display of pupolar course cards in landingpage

### DIFF
--- a/app-next/components/LandingPage/PopularCoursesSection/PopularCoursesSection.module.css
+++ b/app-next/components/LandingPage/PopularCoursesSection/PopularCoursesSection.module.css
@@ -150,7 +150,7 @@
 /* Extra large screens → 4 per row */
 @media (min-width: 1400px) {
   .coursesWrapper {
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(3, 1fr);
     max-width: 1320px;
     gap: 36px;
   }


### PR DESCRIPTION
before
<img width="1920" height="971" alt="Screenshot (72)" src="https://github.com/user-attachments/assets/a46000a8-b74b-4e6b-ad75-811c5f394579" />
 
after
<img width="1893" height="889" alt="e02318b3-cd0f-45b8-a716-6288b5c2d035" src="https://github.com/user-attachments/assets/88a75ba4-4d4c-4da9-a22c-c69c6330f20f" />
